### PR TITLE
webpack-merge使って、ビルド環境毎に設定ファイルを分割

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "autoprefixer": "^9.7.3",
     "babel-loader": "^8.0.6",
     "chart.js": "^2.9.3",
+    "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.4.2",
     "dateformat": "^3.0.3",
@@ -38,10 +39,16 @@
     "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10",
-    "webpack-dev-server": "^3.10.1"
+    "webpack-dev-server": "^3.10.1",
+    "webpack-merge": "^4.2.2"
   },
   "browserslist": [
     "defaults",
     "not IE 11"
-  ]
+  ],
+  "scripts": {
+    "start": "webpack-dev-server --inline --hot --config ./webpack.dev.js",
+    "build": "webpack --config ./webpack.prod.js",
+    "dev": "webpack --config ./webpack.dev.js"
+  }
 }

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -9,6 +9,7 @@ const TerserJSPlugin = require("terser-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const globule = require("globule");
 const args = require("args-parser")(process.argv);
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 // 環境名
 const IS_DEVELOP = !("production" in args);
@@ -32,8 +33,6 @@ const getEntriesList = (targetTypes) => {
 }
 
 const app = {
-  mode: IS_DEVELOP ? "development" : "production",
-  devtool: IS_DEVELOP ? "source-map" : false,
   entry: Object.assign(
     {
       app: [
@@ -46,12 +45,6 @@ const app = {
     path: path.resolve(__dirname, DEST_PATH),
     filename: "js/[name].min.js",
     publicPath: "/",
-  },
-  devServer: {
-    contentBase: DEST_PATH,
-    watchContentBase: true,
-    port: 3000,
-    open: true,
   },
   module: {
     rules: [
@@ -79,9 +72,6 @@ const app = {
           loader: MiniCssExtractPlugin.loader,
         }, {
           loader: "css-loader",
-          options: {
-            sourceMap: IS_DEVELOP ? USE_SOURCE_MAP : false,
-          },
         }, {
           loader: "postcss-loader",
           options: {
@@ -91,9 +81,6 @@ const app = {
           },
         }, {
           loader: "sass-loader",
-          options: {
-            sourceMap: IS_DEVELOP ? USE_SOURCE_MAP : false,
-          },
         }],
       },
       {
@@ -112,6 +99,7 @@ const app = {
     extensions: [".js"],
   },
   plugins: [
+    new CleanWebpackPlugin(),
     new MiniCssExtractPlugin({
       filename: "css/style.min.css",
     }),

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -1,0 +1,16 @@
+const path = require("path");
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+// ビルド先パス
+const DEST_PATH = path.join(__dirname, "./public");
+
+module.exports = merge(common[0], {
+    mode: 'development',
+    devtool: 'source-map',        
+    devServer: {
+        contentBase: DEST_PATH,
+        watchContentBase: true,
+        port: 3000,
+        open: true,
+    },
+})

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -1,0 +1,7 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common[0], {
+    mode: 'production',
+    devtool: false,
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -665,6 +665,11 @@
     core-js "^3.3.4"
     regenerator-runtime "^0.13.3"
 
+"@types/anymatch@*":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
+  integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -693,6 +698,44 @@
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/source-list-map@*":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
+  integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/tapable@*":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
+  integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/uglify-js@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"
+  integrity sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
+  dependencies:
+    source-map "^0.6.1"
+
+"@types/webpack-sources@*":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-0.1.6.tgz#3d21dfc2ec0ad0c77758e79362426a9ba7d7cbcb"
+  integrity sha512-FtAWR7wR5ocJ9+nP137DV81tveD/ZgB1sadnJ/axUGM3BUVfRPx8oQNMtv3JNfTeHx3VP7cXiyfR/jmtEsVHsQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/source-list-map" "*"
+    source-map "^0.6.1"
+
+"@types/webpack@^4.4.31":
+  version "4.41.8"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.8.tgz#d2244f5f612ee30230a5c8c4ae678bce90d27277"
+  integrity sha512-mh4litLHTlDG84TGCFv1pZldndI34vkrW9Mks++Zx4KET7DRMoCXUvLbTISiuF4++fMgNnhV9cc1nCXJQyBYbQ==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    source-map "^0.6.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -1632,6 +1675,14 @@ clean-css@4.2.x:
   integrity sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==
   dependencies:
     source-map "~0.6.0"
+
+clean-webpack-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz#a99d8ec34c1c628a4541567aa7b457446460c62b"
+  integrity sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==
+  dependencies:
+    "@types/webpack" "^4.4.31"
+    del "^4.1.1"
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -7488,6 +7539,13 @@ webpack-log@^2.0.0:
   dependencies:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
+
+webpack-merge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
+  integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
+  dependencies:
+    lodash "^4.17.15"
 
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"


### PR DESCRIPTION
argsで環境を切り分けずに、環境毎にwebpack設定ファイルを作成しました。
ついでに、「npm run」でビルドとサーバの起動できるようにしました。

暇だから、作成しただけなので別にmergeしなくても問題ないです。
とりあえず、webpack-merge使うと、環境毎にファイル切り分けれるよってことを言いたかった。

参考
https://qiita.com/teinen_qiita/items/4e828ac30221efb624e1
https://qiita.com/LuckyRetriever/items/7d2a52f0a6a5847890d0